### PR TITLE
ci: Newer MacOS Intel runner (and install right package)

### DIFF
--- a/.github/workflows/brewtest.yml
+++ b/.github/workflows/brewtest.yml
@@ -12,9 +12,7 @@ jobs:
   test-brew-install:
     strategy:
       matrix:
-        # macos-13 is the last Intel-based runner
-        # macos-latest is Apple Silicon (ARM64)
-        os: [macos-13, macos-latest]
+        os: [macos-15-intel, macos-latest]
     
     runs-on: ${{ matrix.os }}
     
@@ -23,7 +21,7 @@ jobs:
       - name: Install Package from Homebrew
         run: |
           brew tap atsign-foundation/homebrew-tap
-          brew install jq
+          brew install noports
 
       - name: Display Architecture and Version
         run: |


### PR DESCRIPTION
Older MacOS Intel runner doesn't exist

Installed `jq` rather than `noports` :man_facepalming: 

**- What I did**

* Bump runner to `macos-15-intel`
* Install `noports`

**- How to verify it**

CI will run on merge

**- Description for the changelog**

ci: Newer MacOS Intel runner (and install right package)
