### PR TITLE
fix: Use --help to avoid no zero exit code from --version

### DIFF
--- a/.github/workflows/brewtest.yml
+++ b/.github/workflows/brewtest.yml
@@ -32,4 +32,4 @@ jobs:
           which sshnp
           
           echo "Package version info:"
-          sshnp --version
+          sshnp --help


### PR DESCRIPTION
Until v5.14.7 is released with `--version` support we get a non zero exit code for `--version`

**- What I did**

Use `--help` instead

**- How to verify it**

CI will run on merge

**- Description for the changelog**

fix: Use --help to avoid no zero exit code from --version