### PR TITLE
fix: Revert to using sshnp for version check

### DIFF
--- a/.github/workflows/brewtest.yml
+++ b/.github/workflows/brewtest.yml
@@ -32,4 +32,4 @@ jobs:
           which noports
           
           echo "Package version info:"
-          noports --version
+          sshnp --version


### PR DESCRIPTION
`noports --version` doesn't work yet. Opened https://github.com/atsign-foundation/noports/issues/2544 

**- What I did**

Reverted to using `sshnp --version`

**- How to verify it**

Manual run of action

**- Description for the changelog**

fix: Revert to using sshnp for version check
